### PR TITLE
Home Page Progress Section Part 2

### DIFF
--- a/src/api/assignments.ts
+++ b/src/api/assignments.ts
@@ -31,15 +31,25 @@ async function getAssignments(query = '') {
 }
 
 async function getKanjiAssignments(query = '') {
-    return await getAssignments('?subject_types=kanji&');
+    return await getAssignments('?subject_types=kanji');
 }
 
 async function getKanjiAssignmentsAtLevel(level: number) {
     return await getAssignments(`?subject_types=kanji&levels=${level}`);
 }
 
+async function getRadicalAssignments(query = '') {
+    return await getAssignments('?subject_types=radical');
+}
+
+async function getRadicalAssignmentsAtLevel(level: number) {
+    return await getAssignments(`?subject_types=radical&levels=${level}`);
+}
+
 export const AssignmentsAPI = {
     getAssignments,
     getKanjiAssignments,
-    getKanjiAssignmentsAtLevel
+    getKanjiAssignmentsAtLevel,
+    getRadicalAssignments,
+    getRadicalAssignmentsAtLevel
 }

--- a/src/api/subjects.ts
+++ b/src/api/subjects.ts
@@ -2,35 +2,7 @@ import * as SecureStore from "expo-secure-store";
 
 const WEB_URL = "https://api.wanikani.com/v2";
 
-async function getAllSubjects() {
-    const apiToken = SecureStore.getItem('WK_TOKEN');
-
-    if (apiToken) {
-        const headers: Headers = new Headers();
-        headers.set('Authorization', `Bearer ${apiToken}`);
-        headers.set('Wanikani-Revision', '20170710');
-
-        const response = await fetch(`${WEB_URL}/subjects`, {
-            method: "GET",
-            headers: headers
-        });
-
-        if (!response.ok) {
-            switch (response.status){
-                case 401:
-                    throw new Error("Unauthorized: Invalid API token");
-                case 404:
-                    throw new Error("Not Found: Endpoint does not exist");
-                default:
-                    throw new Error(`API Error: ${response.status} ${response.statusText}`);
-            }
-        } else {
-            return await response.json();
-        }
-    }
-}
-
-async function getAllKanji(query = '') {
+async function getAllSubjects(query='') {
     const apiToken = SecureStore.getItem('WK_TOKEN');
 
     if (apiToken) {
@@ -58,12 +30,26 @@ async function getAllKanji(query = '') {
     }
 }
 
+async function getAllKanji() {
+    return await getAllSubjects('?types=kanji');
+}
+
 async function getKanjiAtLevel(level: number) {
-    return await getAllKanji(`?types=kanji&levels=${level}`);
+    return await getAllSubjects(`?types=kanji&levels=${level}`);
+}
+
+async function getAllRadicals() {
+    return await getAllSubjects('?types=radical');
+}
+
+async function getRadicalsAtLevel(level: number) {
+    return await getAllSubjects(`?types=radical&levels=${level}`);
 }
 
 export const SubjectsAPI = {
     getAllSubjects,
     getAllKanji,
-    getKanjiAtLevel
+    getKanjiAtLevel,
+    getAllRadicals,
+    getRadicalsAtLevel
 }

--- a/src/components/home/progress/ProgressSection.tsx
+++ b/src/components/home/progress/ProgressSection.tsx
@@ -22,6 +22,7 @@ import { UserAPI } from '../../../api/user';
 
 // Components
 import Bar from './Bar';
+import Subjects from './Subjects';
 
 interface ProgressSectionProps {
   label: string
@@ -59,6 +60,8 @@ const ProgressSection: React.FC<ProgressSectionProps> = ({ label }) => {
     <View style={HomeStyles.progress_container}>
       <Text>Level {userLevel} Progress</Text>
       <Bar level={userLevel}/>
+      <Subjects level={userLevel} type={"radicals"}/>
+      <Subjects level={userLevel} type={"kanji"}/>
     </View>
   );
 }

--- a/src/components/home/progress/Subject.tsx
+++ b/src/components/home/progress/Subject.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+// Styling
+import { Colors } from '../../../constants/colors';
+import { ProgressStyles } from '../../../styles/home/progress.styles';
+
+type SubjectType = 'radicals' | 'kanji';
+
+interface SubjectProps {
+  type: SubjectType,
+  data: { data: { characters: string }, srs_stage: number }
+}
+
+const typeColors: Record<SubjectType, string> & { default: string } = {
+  radicals: Colors.RADICAL_BLUE,
+  kanji: Colors.KANJI_PINK,
+  default: Colors.OPTIONS_GREY
+};
+
+const Subject: React.FC<SubjectProps> = ({ type, data }) => {
+
+  const characterColor = data.srs_stage === 0 ? Colors.OPTIONS_GREY : (typeColors[type] || typeColors.default);
+
+  return (
+    <View style={ProgressStyles.subject}>
+
+      {/* Subject Text and Background */}
+      <View style={[ProgressStyles.subject_character, { backgroundColor: characterColor }]}>
+        <Text style={{ color: '#ffffff' }}>{data?.data?.characters || '?'}</Text>
+      </View>
+
+      {/* SRS Progression */}
+      <View style={ProgressStyles.subject_bar}>
+        <View style={[ProgressStyles.subject_bar_filler, { width: `${(data.srs_stage / 5) * 100}%` }]}/>
+      </View>
+
+    </View>
+  )
+}
+
+export default Subject;

--- a/src/components/home/progress/Subjects.tsx
+++ b/src/components/home/progress/Subjects.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import { View, Text } from "react-native";
+
+// Styling
+import { ProgressStyles } from '../../../styles/home/progress.styles';
+
+// API
+import { SubjectsAPI } from '../../../api/subjects';
+import { AssignmentsAPI } from '../../../api/assignments';
+
+// Components
+import Subject from './Subject';
+
+interface SubjectsProps {
+    level: number,
+    type: string
+}
+
+const Subjects: React.FC<SubjectsProps> = ({ level, type }) => {
+    const [subjects, setSubjects] = useState([]);
+
+    useEffect(() => {
+        //  Getting the appropriate functions and storing them as pointers
+        const getSubjectAssignments = type === 'radicals' ? AssignmentsAPI.getRadicalAssignmentsAtLevel : AssignmentsAPI.getKanjiAssignmentsAtLevel;
+        const getSubjects = type === 'radicals' ? SubjectsAPI.getRadicalsAtLevel : SubjectsAPI.getKanjiAtLevel;
+
+        const fetchKanji = async () => {
+            try {
+                // Get all user-seen subject assignments at current level
+                const allLearnedRaw = await getSubjectAssignments(level);
+                // Get all assignments from site at current level
+                const allSubjectsRaw = await getSubjects(level);
+
+                if (allLearnedRaw && allSubjectsRaw) {
+                    // Merging all subjects into one collection and sorting based on SRS value
+                    const allLearned = new Map(allLearnedRaw.data.map((learned: { data: { subject_id: number, srs_stage: number } }) => [learned.data.subject_id, learned.data.srs_stage]));
+                    const allSubjects = allSubjectsRaw.data.map((subject: { id: number }) => ({
+                        ...subject,
+                        srs_stage: allLearned.get(subject.id) ?? 0
+                    })).sort((a,b) => b.srs_stage - a.srs_stage);
+
+                    setSubjects(allSubjects);
+                }
+            } catch (e) {
+                console.error(e);
+            } finally {
+                // No cleanup needed
+            }
+        }
+        fetchKanji();
+    });
+
+    return (
+        <View style={ProgressStyles.subject_container}>
+            <Text style={ProgressStyles.label}>{type.charAt(0).toUpperCase() + type.slice(1)}</Text>
+            <View style={ProgressStyles.subject_table}>
+                {subjects.map((subject: { id: number; data: { characters: string }; srs_stage: number }, index) => (
+                    <Subject key={subject.id || index} type={type} data={subject} />
+                ))}
+            </View>
+        </View>
+    )
+}
+
+export default Subjects;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -9,6 +9,7 @@ export const Colors: { [key: string]: string} = {
     VOCAB_PURPLE: "#AA00FF",
     KANJI_PINK: "#FF00AA",
     RADICAL_BLUE: "#00AAFF",
+    CORRECT_GREEN: "#35A753",
     LESSON_GREY: "#808080",
     LESSON_LIGHT_GREY: "#ecececff",
     OPTIONS_GREY: "#D5D5D5",

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -10,6 +10,7 @@ export const Colors: { [key: string]: string} = {
     KANJI_PINK: "#FF00AA",
     RADICAL_BLUE: "#00AAFF",
     LESSON_GREY: "#808080",
+    LESSON_LIGHT_GREY: "#ecececff",
     OPTIONS_GREY: "#D5D5D5",
     HEADER_WHITE: "#FFFFFF"
 };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -23,7 +23,7 @@ const HomeScreen = () => {
       <View style={HomeStyles.header_container}>
         <Image 
           style={HomeStyles.header_image}
-          source={require('../assets/images/icons/wk_banner_logo.png')}>
+          source={require('../../assets/images/icons/wk_banner_logo.png')}>
         </Image>
       </View>
 

--- a/src/styles/globals.ts
+++ b/src/styles/globals.ts
@@ -36,11 +36,11 @@ export const HomeStyles = StyleSheet.create({
     header_container: {
         height: 45,
         width: '100%',
-        backgroundColor: Colors.HEADER_WHITE,
+        backgroundColor: Colors.LESSON_LIGHT_GREY,
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'center',
-        borderWidth: 1,
+        // borderWidth: 1, 
     },
     header_image: {
         height: '50%', // XXX: Not sure how this will look on other devices
@@ -53,10 +53,11 @@ export const HomeStyles = StyleSheet.create({
         flexDirection: 'row',
     },
     progress_container: {
-        backgroundColor: Colors.HEADER_WHITE,
+        backgroundColor: Colors.LESSON_LIGHT_GREY,
         justifyContent: 'space-around',
         width: '95%',
-        padding: 10
+        padding: 10,
+        gap: 10
     },
     review_box: {
         width: '48%',

--- a/src/styles/home/progress.styles.ts
+++ b/src/styles/home/progress.styles.ts
@@ -9,6 +9,7 @@ import { StyleSheet } from 'react-native';
 import { Colors } from '../../constants/colors';
 
 export const ProgressStyles = StyleSheet.create({
+    // Level Progression / Progress Bar
     bar: {
         height: 20,
         width: '100%',
@@ -25,5 +26,47 @@ export const ProgressStyles = StyleSheet.create({
     },
     label: {
         paddingLeft: 5
-    }
+    },
+    // Kanji/Radical Progression Table
+    subject_container: {
+        backgroundColor: '#ffffff',
+    },
+    subject_table: {
+        backgroundColor: '#ffffff',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'flex-start',
+        width: '100%',
+        padding: 5,
+        gap: 10,
+        marginBottom: 5
+    },
+    subject: {
+        backgroundColor: '#ffffff',
+        width: '10%',
+        height: 50,
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+        gap: 10,
+        marginBottom: 10
+    },
+    subject_character: {
+        width: '90%',
+        height: '70%',
+        backgroundColor: Colors.OPTIONS_GREY,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 8
+    },
+    subject_bar: {
+        backgroundColor: Colors.OPTIONS_GREY,
+        height: '20%',
+        width: '100%',
+        borderRadius: 30,
+    },
+    subject_bar_filler: {
+        height: '100%',
+        backgroundColor: Colors.CORRECT_GREEN,
+        borderRadius: 30,
+    },
 });


### PR DESCRIPTION
This update introduces a structured subject table for radicals and kanji within the Home page’s progress section.

Key Features:
* Adds a table view displaying Kanji and Radical assignments for the current level
* Integrates a progress bar indicating the SRS level (1–5) for each Kanji and Radical

Additional Improvements:
* Added new API calls and simplified existing API functions
* Slight altering to Home Page styles
* Small fix to image source path in Home Screen component