### PR TITLE
Home Page -  SRS Stage bug fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,8 @@
 - Fix resizing with wk logo on header bar (globals.ts)
+- Adjust alignment of subjects
+- Some assignments have an SRS value > 5
+
+- Screens to Implement
+    * Review Screen
+    * Assignment Screen
+    * Subject Screen

--- a/src/components/home/progress/Bar.tsx
+++ b/src/components/home/progress/Bar.tsx
@@ -41,7 +41,7 @@ const Bar: React.FC<BarProps> = ({ level }) => {
         if (allLearned && allKanji) {
           // Count mastered kanji (SRS stage 5)
           let numLearned = allLearned.data.reduce(
-            (sum: number, kanji: { data: { srs_stage: number; }; }) => sum + (kanji?.data?.srs_stage === 5 ? 1 : 0),
+            (sum: number, kanji: { data: { srs_stage: number; }; }) => sum + (kanji?.data?.srs_stage >= 5 ? 1 : 0),
             0
           );
           setLearned(numLearned);
@@ -57,7 +57,7 @@ const Bar: React.FC<BarProps> = ({ level }) => {
   });
 
   // Calculate progress percentage
-  const progress = (learned / kanji) * 100 || 0;
+  const progress = (Math.min(learned / kanji, 1)) * 100 || 0;
 
   return (
     <View style={ProgressStyles.bar}>

--- a/src/components/home/progress/Subject.tsx
+++ b/src/components/home/progress/Subject.tsx
@@ -32,7 +32,7 @@ const Subject: React.FC<SubjectProps> = ({ type, data }) => {
 
       {/* SRS Progression */}
       <View style={ProgressStyles.subject_bar}>
-        <View style={[ProgressStyles.subject_bar_filler, { width: `${(data.srs_stage / 5) * 100}%` }]}/>
+        <View style={[ProgressStyles.subject_bar_filler, { width: `${Math.min((data.srs_stage / 5), 1) * 100}%` }]}/>
       </View>
 
     </View>


### PR DESCRIPTION
This minor update resolves a bug affecting items with an SRS stage greater than 5. Previously, this issue caused inaccuracies in the `masteredKanji` count and misrepresented progress within the subject table’s progress bar.