### PR TITLE
Kana Vocabulary Fixes

### DIFF
--- a/src/components/global/WanaKanaInput.tsx
+++ b/src/components/global/WanaKanaInput.tsx
@@ -6,7 +6,6 @@
  *
  * @param {WKIProps} q_type - The quiz type.
  * @param {WKIProps} answers - A list of acceptable readings/meanings
- * @param {WKIProps} is_kana - A flag used to convert text to Katakana
  *
  * @returns {JSX.Element}
  */

--- a/src/components/global/WanaKanaInput.tsx
+++ b/src/components/global/WanaKanaInput.tsx
@@ -38,11 +38,13 @@ interface WKIProps extends TextInputProps {
 const WanaKanaInput = forwardRef<WanaKanaInputRef, WKIProps>(
     ({ style, ...props }, ref) => {
         const [text, setText] = useState("");
-        const is_hiragana = useRef(isHiragana(props.answers[0]?.reading));
+        const is_katakana = useRef(
+            isKatakana(props.answers?.[0]?.reading || "")
+        );
 
         const handleChangeText = (input: string) => {
             if (props.q_type === "reading") {
-                const textConverter = is_hiragana ? toHiragana : toKatakana;
+                const textConverter = is_katakana ? toKatakana : toHiragana;
                 const converted_text = textConverter(input, { IMEMode: true });
                 setText(converted_text);
             } else {
@@ -65,7 +67,7 @@ const WanaKanaInput = forwardRef<WanaKanaInputRef, WKIProps>(
             },
             isValid: () => {
                 if (props.q_type === "reading") {
-                    const syntaxChecker = is_hiragana ? isHiragana : isKatakana;
+                    const syntaxChecker = is_katakana ? isKatakana : isHiragana;
 
                     return syntaxChecker(text);
                 } else {

--- a/src/components/global/WanaKanaInput.tsx
+++ b/src/components/global/WanaKanaInput.tsx
@@ -10,7 +10,12 @@
  *
  * @returns {JSX.Element}
  */
-import React, { useState, forwardRef, useImperativeHandle } from "react";
+import React, {
+    useState,
+    useRef,
+    forwardRef,
+    useImperativeHandle,
+} from "react";
 import { TextInput, TextInputProps } from "react-native";
 import { isHiragana, toHiragana, isKatakana, toKatakana } from "wanakana";
 
@@ -29,16 +34,16 @@ interface WKIProps extends TextInputProps {
         type?: string;
         primary: boolean;
     }[];
-    is_kana: boolean;
 }
 
 const WanaKanaInput = forwardRef<WanaKanaInputRef, WKIProps>(
     ({ style, ...props }, ref) => {
         const [text, setText] = useState("");
+        const is_hiragana = useRef(isHiragana(props.answers[0]?.reading));
 
         const handleChangeText = (input: string) => {
             if (props.q_type === "reading") {
-                const textConverter = props.is_kana ? toKatakana : toHiragana;
+                const textConverter = is_hiragana ? toHiragana : toKatakana;
                 const converted_text = textConverter(input, { IMEMode: true });
                 setText(converted_text);
             } else {
@@ -61,9 +66,7 @@ const WanaKanaInput = forwardRef<WanaKanaInputRef, WKIProps>(
             },
             isValid: () => {
                 if (props.q_type === "reading") {
-                    const syntaxChecker = props.is_kana
-                        ? isKatakana
-                        : isHiragana;
+                    const syntaxChecker = is_hiragana ? isHiragana : isKatakana;
 
                     return syntaxChecker(text);
                 } else {

--- a/src/interfaces/Subject.ts
+++ b/src/interfaces/Subject.ts
@@ -27,5 +27,5 @@ export interface SubjectProps {
         kanji?: Array<SubjectProps>;
         vocabulary?: Array<SubjectProps>;
     };
-    is_kana: boolean;
+    is_kana_vocabulary: boolean;
 }

--- a/src/screens/ReviewScreen.tsx
+++ b/src/screens/ReviewScreen.tsx
@@ -385,7 +385,6 @@ const ReviewScreen = (nav: {
                                 ? subject.meanings
                                 : subject.readings
                         }
-                        is_kana={subject.is_kana}
                         editable={!submitted}
                         onSubmitEditing={submitResponse}
                     />

--- a/src/screens/ReviewScreen.tsx
+++ b/src/screens/ReviewScreen.tsx
@@ -146,9 +146,10 @@ const ReviewScreen = (nav: {
                 quiz_state = quizStates.get(subject.id);
 
                 // pass the subject back into array if user hasn't been quizzed on both
-                // reading and meaning (meaning for radicals)
+                // reading and meaning (meaning for radicals and kana_vocabulary)
                 if (
-                    (subject.type === "radical" &&
+                    ((subject.type === "radical" ||
+                        subject.is_kana_vocabulary) &&
                         !quiz_state?.meaning_attempt) ||
                     (subject.type !== "radical" &&
                         (!quiz_state?.reading_attempt ||
@@ -160,7 +161,8 @@ const ReviewScreen = (nav: {
 
                 // create a review object to send to API once user has been fully quizzed
                 if (
-                    (subject.type === "radical" &&
+                    ((subject.type === "radical" ||
+                        subject.is_kana_vocabulary) &&
                         quiz_state?.meaning_attempt) ||
                     (subject.type !== "radical" &&
                         quiz_state?.reading_attempt &&
@@ -205,7 +207,10 @@ const ReviewScreen = (nav: {
 
             // Both false - choose randomly
             if (!meaning_attempted && !reading_attempted) {
-                if (nextSubj?.type === "radical") {
+                if (
+                    nextSubj?.type === "radical" ||
+                    nextSubj?.is_kana_vocabulary
+                ) {
                     return "meaning";
                 } else {
                     return Math.random() > 0.5 ? "meaning" : "reading";

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -44,7 +44,7 @@ function convertSubject(subject_raw: RawSubjectProps) {
             ...(subject_raw.data?.component_subject_ids || []),
             ...(subject_raw.data?.visually_similar_subject_ids || []),
         ],
-        is_kana: subject_raw.object === "kana_vocabulary",
+        is_kana_vocabulary: subject_raw.object === "kana_vocabulary",
     };
     switch (converted_subject.type) {
         case "radical":


### PR DESCRIPTION
Changes how Kana Vocabulary subject types are handled in the `ReviewScreen` and `WanaKanaInput` component.

These subjects are to be treated like Radicals in that only the meaning is tested on. Additionally, I have added a check inside `WanaKanaInput` that looks at the primary reading of a subject to determine whether or not to answer in katakana or hiragana.