### PR TITLE
Lesson Batch Size + API Bug Fix

### DIFF
--- a/src/api/assignments.ts
+++ b/src/api/assignments.ts
@@ -19,11 +19,6 @@ async function putAssignment(assignment: ReviewProps) {
             {
                 method: "PUT",
                 headers: headers,
-                body: JSON.stringify({
-                    assignment: {
-                        started_at: assignment.started_at,
-                    },
-                }),
             }
         );
 

--- a/src/api/assignments.ts
+++ b/src/api/assignments.ts
@@ -71,12 +71,11 @@ async function getAvailableLessons() {
     const assignments = await getAssignments(
         "?immediately_available_for_lessons=true"
     );
-    const lessonsPerSession = 15; // NOTE: not sure how WK gets the session batch size, hardcoding for now...
 
     return {
         ...assignments,
-        data: assignments.data.slice(0, lessonsPerSession),
-        total_count: lessonsPerSession,
+        data: assignments.data,
+        total_count: assignments.data.length,
     };
 }
 

--- a/src/components/home/dashboard/AssignmentCard.tsx
+++ b/src/components/home/dashboard/AssignmentCard.tsx
@@ -81,6 +81,8 @@ const AssignmentCard: React.FC<AssignmentProps> = ({
         });
     };
     const goToLessons = async () => {
+        const batch_size = 15; // NOTE: Temporary, swap for user pref in future
+
         const review_ids = assignments
             .map((assignment) => {
                 return assignment.data.subject_id;
@@ -103,7 +105,9 @@ const AssignmentCard: React.FC<AssignmentProps> = ({
             })
         );
 
-        navigation.navigate("Lesson", { subjects: subjects_with_assignments });
+        navigation.navigate("Lesson", {
+            subjects: subjects_with_assignments.slice(0, batch_size),
+        });
     };
 
     const AssignmentStyles = {

--- a/src/screens/ReviewScreen.tsx
+++ b/src/screens/ReviewScreen.tsx
@@ -89,10 +89,8 @@ const ReviewScreen = (nav: {
 
         if (subject) {
             switch (s_type) {
-                // NOTE: Unneeded but leaving for clarity
-                //
-                // case "lesson":
-                //     review.started_at = timestamp;
+                case "lesson":
+                    review.assignment_id = subject?.assignment_id;
                 case "review":
                     review.assignment_id = subject?.assignment_id;
                     review.incorrect_meaning_answers =


### PR DESCRIPTION
This update revolves around lesson assignments.

There was previously a bug where lessons weren't being recorded to the API because the assignment obj lacked the `assignment_id` field. This has been fixed.

I also edited the assignment API function `getAvailableLessons` to return all of the available lessons, not just the first 15. When hitting the Lessons dashboard card, the first 15 of all these lessons are sent to LessonScreen.