### PR TITLE
SubjectDefinition.tsx: removing selectable attribute from reading/meaning explanations

### DIFF
--- a/src/components/subject/SubjectMeaning.tsx
+++ b/src/components/subject/SubjectMeaning.tsx
@@ -91,7 +91,7 @@ const SubjectMeaning: React.FC<SubjectMeaningProps> = ({
                     paddingBottom: 12,
                 }}
             >
-                <Text selectable style={{ color: Colors.LESSON_GREY }}>
+                <Text style={{ color: Colors.LESSON_GREY }}>
                     <RichText text={meaning_explanation} />
                 </Text>
             </View>

--- a/src/components/subject/SubjectReading.tsx
+++ b/src/components/subject/SubjectReading.tsx
@@ -202,7 +202,7 @@ const SubjectReading: React.FC<SubjectReadingProps> = ({
                     paddingBottom: 12,
                 }}
             >
-                <Text selectable style={{ color: Colors.LESSON_GREY }}>
+                <Text style={{ color: Colors.LESSON_GREY }}>
                     <RichText text={reading_explanation} />
                 </Text>
             </View>


### PR DESCRIPTION
Started getting annoying when scrolling through the page